### PR TITLE
Remove android:allowBackup

### DIFF
--- a/debot-no-op/src/main/AndroidManifest.xml
+++ b/debot-no-op/src/main/AndroidManifest.xml
@@ -1,9 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.tomoima.debot">
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-        >
+    <application android:label="@string/app_name" >
 
     </application>
 

--- a/debot/src/main/AndroidManifest.xml
+++ b/debot/src/main/AndroidManifest.xml
@@ -1,9 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.tomoima.debot">
 
-    <application android:allowBackup="true"
-                 android:label="@string/app_name"
-        >
+    <application android:label="@string/app_name">
 
     </application>
 


### PR DESCRIPTION
Including android:allowBackup in the library forces me to use two lines to bypass it in my own application tp bypass it.

If there is no need for it in this library I suggest you to remove it. :-)

android:allowBackup="false"
tools:replace="android:allowBackup"