### PR TITLE
Fix memory leak of debot dialog

### DIFF
--- a/debot/src/main/java/com/tomoima/debot/Debot.kt
+++ b/debot/src/main/java/com/tomoima/debot/Debot.kt
@@ -10,7 +10,6 @@ import com.squareup.seismic.ShakeDetector
 import java.lang.ref.WeakReference
 
 class Debot private constructor() {
-    private val debotDialog: DebotDialog = DebotDialog.get()
     private var sd: ShakeDetector? = null
     private var sensorManager: SensorManager? = null
     private var activityWeakRef: WeakReference<FragmentActivity>? = null
@@ -34,7 +33,7 @@ class Debot private constructor() {
     }
 
     fun showDebugMenu(activity: FragmentActivity?) {
-        debotDialog.showDebugMenu(activity)
+        DebotDialog.get().showDebugMenu(activity)
     }
 
     private fun setupSensor(context: Context) {


### PR DESCRIPTION
## Overview
`DebotDialog` is leaked when it is dismissed.

<img src="https://user-images.githubusercontent.com/12001860/48974802-405eeb80-f0a6-11e8-8d2d-7acd794b52c3.png" width="250">

`DebotDialog` extends `DialogFragment` so its lifecycle should be managed by FragmentManager. However `Debot` has reference to this class as a member variable. This prevent `DebotDialog` from being the target of GC. Let's stop to have `debotDialog` as a member of `Debot` .

You can confirm that memory leak has been fixed from this environment: https://github.com/atsuko-fukui/debot/commit/c76fede46c493affae6fec997910f288b9052455