### PR TITLE
Migrate to Androidx

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 apply from: 'dependencies.gradle'
 buildscript {
-    ext.kotlin_version = '1.3.10'
+    ext.kotlin_version = '1.3.72'
     ext.library_version = System.getenv('CI') ? "2.0.6-SNAPSHOT" : '2.0.5'
     ext.bintray_user = project.hasProperty("BINTRAY_USER") ? BINTRAY_USER : ""
     ext.bintray_key = project.hasProperty('BINTRAY_KEY') ? BINTRAY_KEY : ""

--- a/debot-no-op/build.gradle
+++ b/debot-no-op/build.gradle
@@ -49,7 +49,7 @@ tasks.withType(Javadoc) {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "com.android.support:appcompat-v7:$versions.supportLibrary"
+    implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 

--- a/debot-no-op/build.gradle
+++ b/debot-no-op/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'com.novoda.bintray-release'
 apply plugin: 'maven-publish'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/debot-no-op/src/main/java/com/tomoima/debot/Debot.kt
+++ b/debot-no-op/src/main/java/com/tomoima/debot/Debot.kt
@@ -1,7 +1,7 @@
 package com.tomoima.debot
 
 import android.content.Context
-import android.support.v4.app.FragmentActivity
+import androidx.fragment.app.FragmentActivity
 
 class Debot private constructor()//Do nothing
 {

--- a/debot-no-op/src/main/java/com/tomoima/debot/strategy/DebotCallActivityMethodStrategy.java
+++ b/debot-no-op/src/main/java/com/tomoima/debot/strategy/DebotCallActivityMethodStrategy.java
@@ -2,7 +2,7 @@ package com.tomoima.debot.strategy;
 
 
 import android.app.Activity;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 
 public class DebotCallActivityMethodStrategy extends DebotStrategy{

--- a/debot-sample/build.gradle
+++ b/debot-sample/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         applicationId "com.tomoima.debot.sample"
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }

--- a/debot-sample/build.gradle
+++ b/debot-sample/build.gradle
@@ -20,7 +20,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "com.android.support:appcompat-v7:$versions.supportLibrary"
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation project(':debot')
     // Replace with debot-no-op for looking no-op sample
     //compile project(':debot-no-op')

--- a/debot-sample/src/main/java/com/tomoima/debot/sample/activity/BaseActivity.java
+++ b/debot-sample/src/main/java/com/tomoima/debot/sample/activity/BaseActivity.java
@@ -1,8 +1,8 @@
 package com.tomoima.debot.sample.activity;
 
 import android.os.Bundle;
-import android.support.annotation.Nullable;
-import android.support.v7.app.AppCompatActivity;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AppCompatActivity;
 import android.view.KeyEvent;
 
 import com.tomoima.debot.Debot;

--- a/debot-sample/src/main/java/com/tomoima/debot/sample/fragments/BaseFragment.java
+++ b/debot-sample/src/main/java/com/tomoima/debot/sample/fragments/BaseFragment.java
@@ -3,7 +3,7 @@ package com.tomoima.debot.sample.fragments;
 import android.app.Activity;
 import android.content.Context;
 import android.content.res.Resources;
-import android.support.v4.app.Fragment;
+import androidx.fragment.app.Fragment;
 import android.view.View;
 
 import com.tomoima.debot.sample.MyApplication;

--- a/debot-sample/src/main/java/com/tomoima/debot/sample/fragments/NextActivityFragment.java
+++ b/debot-sample/src/main/java/com/tomoima/debot/sample/fragments/NextActivityFragment.java
@@ -1,6 +1,6 @@
 package com.tomoima.debot.sample.fragments;
 
-import android.support.v4.app.Fragment;
+import androidx.fragment.app.Fragment;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;

--- a/debot-sample/src/main/java/com/tomoima/debot/sample/strategy/MyCustomStrategy.java
+++ b/debot-sample/src/main/java/com/tomoima/debot/sample/strategy/MyCustomStrategy.java
@@ -1,7 +1,7 @@
 package com.tomoima.debot.sample.strategy;
 
 import android.app.Activity;
-import android.support.annotation.NonNull;
+import androidx.annotation.NonNull;
 
 import com.tomoima.debot.strategy.DebotStrategy;
 

--- a/debot/build.gradle
+++ b/debot/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'com.novoda.bintray-release'
 apply plugin: 'maven-publish'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 27
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/debot/build.gradle
+++ b/debot/build.gradle
@@ -11,7 +11,7 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
     }
     buildTypes {
         release {
@@ -32,11 +32,11 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "com.android.support:appcompat-v7:$versions.supportLibrary"
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation "com.squareup:seismic:$versions.seismic"
 
-    androidTestImplementation "com.android.support.test:runner:$versions.testRunner"
-    androidTestImplementation "com.android.support.test:rules:$versions.testRunner"
+    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    androidTestImplementation 'androidx.test:rules:1.1.1'
     androidTestImplementation "org.hamcrest:hamcrest-library:$versions.hamcrest"
     androidTestImplementation("org.mockito:mockito-core:$versions.mockitoCore") {
         exclude group: 'org.hamcrest', module: 'hamcrest-core'

--- a/debot/src/androidTest/java/com/tomoima/debot/DebotDialogTest.kt
+++ b/debot/src/androidTest/java/com/tomoima/debot/DebotDialogTest.kt
@@ -3,11 +3,11 @@ package com.tomoima.debot
 
 import android.app.Activity
 import android.app.Dialog
-import android.support.test.rule.ActivityTestRule
-import android.support.test.runner.AndroidJUnit4
-import android.support.v4.app.Fragment
-import android.support.v4.app.FragmentManager
-import android.support.v7.app.AppCompatActivity
+import androidx.test.rule.ActivityTestRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.appcompat.app.AppCompatActivity
 import com.nhaarman.mockito_kotlin.whenever
 import com.tomoima.debot.strategy.DebotStrategy
 import org.junit.Before

--- a/debot/src/androidTest/java/com/tomoima/debot/DebotTestUtils.kt
+++ b/debot/src/androidTest/java/com/tomoima/debot/DebotTestUtils.kt
@@ -3,9 +3,7 @@ package com.tomoima.debot
 
 import android.app.Activity
 import android.app.Dialog
-import android.content.DialogInterface
-import android.support.test.InstrumentationRegistry.getInstrumentation
-import android.support.v4.app.FragmentManager
+import androidx.test.platform.app.InstrumentationRegistry.getInstrumentation
 import org.mockito.Mockito.*
 import java.util.concurrent.CountDownLatch
 
@@ -35,10 +33,6 @@ internal object DebotTestUtils {
     }
 
     class TestDebot : DebotDialog() {
-
-        override fun show(manager: FragmentManager, tag: String) {
-
-        }
 
         companion object {
             val instance: TestDebot

--- a/debot/src/main/java/com/tomoima/debot/Debot.kt
+++ b/debot/src/main/java/com/tomoima/debot/Debot.kt
@@ -3,7 +3,7 @@ package com.tomoima.debot
 
 import android.content.Context
 import android.hardware.SensorManager
-import android.support.v4.app.FragmentActivity
+import androidx.fragment.app.FragmentActivity
 
 import com.squareup.seismic.ShakeDetector
 
@@ -23,7 +23,7 @@ class Debot private constructor() {
     fun startSensor(activity: FragmentActivity) {
         if (!canShake) return
         activityWeakRef = WeakReference(activity)
-        sd?.start(sensorManager);
+        sd?.start(sensorManager)
     }
 
     fun stopSensor() {
@@ -32,14 +32,14 @@ class Debot private constructor() {
         sd?.stop()
     }
 
-    fun showDebugMenu(activity: FragmentActivity?) {
+    fun showDebugMenu(activity: FragmentActivity) {
         DebotDialog.get().showDebugMenu(activity)
     }
 
     private fun setupSensor(context: Context) {
         sensorManager = context.getSystemService(Context.SENSOR_SERVICE) as SensorManager
         sd = ShakeDetector(ShakeDetector.Listener {
-            showDebugMenu(activityWeakRef?.get())
+            activityWeakRef?.get()?.let(::showDebugMenu)
         })
         sd?.setSensitivity(ShakeDetector.SENSITIVITY_LIGHT)
     }

--- a/debot/src/main/java/com/tomoima/debot/DebotDialog.kt
+++ b/debot/src/main/java/com/tomoima/debot/DebotDialog.kt
@@ -2,10 +2,9 @@ package com.tomoima.debot
 
 import android.content.DialogInterface
 import android.os.Bundle
-import android.support.annotation.VisibleForTesting
-import android.support.v4.app.DialogFragment
-import android.support.v4.app.FragmentActivity
-import android.support.v4.app.FragmentManager
+import androidx.annotation.VisibleForTesting
+import androidx.fragment.app.FragmentActivity
+import androidx.fragment.app.FragmentManager
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -14,7 +13,7 @@ import android.widget.ListView
 import com.tomoima.debot.adapter.DebotMenuListAdapter
 
 // This class allows others to inherit
-open class DebotDialog : DialogFragment() {
+open class DebotDialog : androidx.fragment.app.DialogFragment() {
     private val TAG = "com.tomoima.debot.Debot"
     private val debotStrategyList = DebotStrategies.get()
 
@@ -50,11 +49,11 @@ open class DebotDialog : DialogFragment() {
     }
 
 
-    fun showDebugMenu(activity: FragmentActivity?) {
-        val fragmentManager = activity?.supportFragmentManager
-        if (fragmentManager?.findFragmentByTag(TAG) == null) {
+    fun showDebugMenu(activity: FragmentActivity) {
+        val fragmentManager = activity.supportFragmentManager
+        if (fragmentManager.findFragmentByTag(TAG) == null) {
                 show(fragmentManager, TAG)
-                fragmentManager?.executePendingTransactions()
+                fragmentManager.executePendingTransactions()
         }
     }
 
@@ -65,8 +64,8 @@ open class DebotDialog : DialogFragment() {
     @VisibleForTesting
     fun dismissDebugMenu(fragmentManager: FragmentManager) {
 
-        val debotDialog: DebotDialog? = fragmentManager.findFragmentByTag(TAG) as DebotDialog
-        debotDialog?.onDismiss(dialog)
+        val debotDialog = fragmentManager.findFragmentByTag(TAG) as? DebotDialog ?: return
+        dialog?.let(debotDialog::onDismiss)
     }
 
     companion object {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.9-all.zip


### PR DESCRIPTION
Thanks for this library!

Currently Debot uses the Android Support library. This means that to compile to an app that uses Androidx, we must use the Jetifier.

This PR migrates the library to Androidx natively, so that the Jetifier is no longer needed.