### PR TITLE
Permission HIGH_SAMPLING_RATE_SENSORS required when targeting Android 12

### DIFF
--- a/debot-no-op/build.gradle
+++ b/debot-no-op/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }

--- a/debot-no-op/src/main/java/com/tomoima/debot/Debot.kt
+++ b/debot-no-op/src/main/java/com/tomoima/debot/Debot.kt
@@ -8,7 +8,8 @@ class Debot private constructor()//Do nothing
 
     fun allowShake(context: Context) {}
 
-    fun startSensor(activity: FragmentActivity, sensorDelay: Int) {}
+    @JvmOverloads
+    fun startSensor(activity: FragmentActivity, sensorDelay: Int = 0) {}
 
     fun stopSensor() {}
 

--- a/debot-no-op/src/main/java/com/tomoima/debot/Debot.kt
+++ b/debot-no-op/src/main/java/com/tomoima/debot/Debot.kt
@@ -8,7 +8,7 @@ class Debot private constructor()//Do nothing
 
     fun allowShake(context: Context) {}
 
-    fun startSensor(activity: FragmentActivity) {}
+    fun startSensor(activity: FragmentActivity, sensorDelay: Int) {}
 
     fun stopSensor() {}
 

--- a/debot-sample/build.gradle
+++ b/debot-sample/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         applicationId "com.tomoima.debot.sample"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }

--- a/debot-sample/src/main/AndroidManifest.xml
+++ b/debot-sample/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
         android:theme="@style/AppTheme" >
         <activity
             android:name="com.tomoima.debot.sample.activity.MainActivity"
+            android:exported="true"
             android:label="@string/app_name" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/debot-sample/src/main/java/com/tomoima/debot/sample/activity/BaseActivity.java
+++ b/debot-sample/src/main/java/com/tomoima/debot/sample/activity/BaseActivity.java
@@ -22,7 +22,7 @@ public class BaseActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        debot.startSensor(this, SensorManager.SENSOR_DELAY_GAME);
+        debot.startSensor(this);
     }
 
     @Override

--- a/debot-sample/src/main/java/com/tomoima/debot/sample/activity/BaseActivity.java
+++ b/debot-sample/src/main/java/com/tomoima/debot/sample/activity/BaseActivity.java
@@ -1,5 +1,6 @@
 package com.tomoima.debot.sample.activity;
 
+import android.hardware.SensorManager;
 import android.os.Bundle;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
@@ -21,7 +22,7 @@ public class BaseActivity extends AppCompatActivity {
     @Override
     protected void onResume() {
         super.onResume();
-        debot.startSensor(this);
+        debot.startSensor(this, SensorManager.SENSOR_DELAY_GAME);
     }
 
     @Override

--- a/debot/build.gradle
+++ b/debot/build.gradle
@@ -4,11 +4,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'maven-publish'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'

--- a/debot/src/main/java/com/tomoima/debot/Debot.kt
+++ b/debot/src/main/java/com/tomoima/debot/Debot.kt
@@ -21,7 +21,7 @@ class Debot private constructor() {
     }
 
     @JvmOverloads
-    fun startSensor(activity: FragmentActivity, sensorDelay: Int = 0) {
+    fun startSensor(activity: FragmentActivity, sensorDelay: Int = SensorManager.SENSOR_DELAY_GAME) {
         if (!canShake) return
         activityWeakRef = WeakReference(activity)
         sd?.start(sensorManager, sensorDelay)

--- a/debot/src/main/java/com/tomoima/debot/Debot.kt
+++ b/debot/src/main/java/com/tomoima/debot/Debot.kt
@@ -20,10 +20,10 @@ class Debot private constructor() {
         setupSensor(context)
     }
 
-    fun startSensor(activity: FragmentActivity) {
+    fun startSensor(activity: FragmentActivity, sensorDelay: Int) {
         if (!canShake) return
         activityWeakRef = WeakReference(activity)
-        sd?.start(sensorManager)
+        sd?.start(sensorManager, sensorDelay)
     }
 
     fun stopSensor() {

--- a/debot/src/main/java/com/tomoima/debot/Debot.kt
+++ b/debot/src/main/java/com/tomoima/debot/Debot.kt
@@ -20,7 +20,8 @@ class Debot private constructor() {
         setupSensor(context)
     }
 
-    fun startSensor(activity: FragmentActivity, sensorDelay: Int) {
+    @JvmOverloads
+    fun startSensor(activity: FragmentActivity, sensorDelay: Int = 0) {
         if (!canShake) return
         activityWeakRef = WeakReference(activity)
         sd?.start(sensorManager, sensorDelay)

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,7 +2,7 @@ ext.versions = [
 
         supportLibrary : '27.1.0',
         androidKtx : '0.2',
-        seismic : '1.0.2',
+        seismic : '1.0.3',
         junit : '4.12',
         testRunner: '1.0.1',
         espressoCore : '3.0.1',


### PR DESCRIPTION
## 問題概要
Android 12対応にあたり、shake detectに利用しているsquareのseismicでエラーが出ています。（エラーログは下記）
Shakeの検知をする際に利用している`ShakeDetector#start()` の第2引数であるsensor start delayの値に0を指定する場合は、Android 12以降では新たなpermission `HIGH_SAMPLING_RATE_SENSORS` が必要というエラーです。

seismicもこれを認識しており、0以外の値が渡せるようにoverload methodが追加されています。

square/seismic#24

## 修正方針
seismicの変更に合わせて`Debot#startSensor()` で、任意のsensor start delayの値を渡せるように変更しました。

修正アプローチとしてはもう一つ、sensor start delay をこれまで通り0で固定して、permissionをつけるというやり方もあります。この方法も既に別のPRが作られているので、お好きな方を採用して下さい。
https://github.com/tomoima525/debot/pull/50

個人的にはsampleを修正した通り、 `SensorManager.SENSOR_DELAY_GAME` でshakeの検出は十分問題ないので、なるべく新たなpermissionをつけるのは避けたいです。


## エラーログ
```
2021-11-09 14:14:18.137 13788-13788/? E/AndroidRuntime: FATAL EXCEPTION: main
    Process: com.tomoima.debot.sample, PID: 13788
    java.lang.RuntimeException: Unable to resume activity {com.tomoima.debot.sample/com.tomoima.debot.sample.activity.MainActivity}: java.lang.SecurityException: To use the sampling rate of 0 microseconds, app needs to declare the normal permission HIGH_SAMPLING_RATE_SENSORS.
        at android.app.ActivityThread.performResumeActivity(ActivityThread.java:4761)
        at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:4794)
        at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:54)
        at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45)
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176)
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2214)
        at android.os.Handler.dispatchMessage(Handler.java:106)
        at android.os.Looper.loopOnce(Looper.java:201)
        at android.os.Looper.loop(Looper.java:288)
        at android.app.ActivityThread.main(ActivityThread.java:7842)
        at java.lang.reflect.Method.invoke(Native Method)
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003)
     Caused by: java.lang.SecurityException: To use the sampling rate of 0 microseconds, app needs to declare the normal permission HIGH_SAMPLING_RATE_SENSORS.
        at android.hardware.SystemSensorManager$BaseEventQueue.enableSensor(SystemSensorManager.java:792)
        at android.hardware.SystemSensorManager$BaseEventQueue.addSensor(SystemSensorManager.java:712)
        at android.hardware.SystemSensorManager.registerListenerImpl(SystemSensorManager.java:209)
        at android.hardware.SensorManager.registerListener(SensorManager.java:832)
        at android.hardware.SensorManager.registerListener(SensorManager.java:739)
        at com.squareup.seismic.ShakeDetector.start(ShakeDetector.java:66)
        at com.tomoima.debot.Debot.startSensor(Debot.kt:26)
        at com.tomoima.debot.sample.activity.BaseActivity.onResume(BaseActivity.java:24)
        at android.app.Instrumentation.callActivityOnResume(Instrumentation.java:1476)
        at android.app.Activity.performResume(Activity.java:8191)
        at android.app.ActivityThread.performResumeActivity(ActivityThread.java:4751)
        at android.app.ActivityThread.handleResumeActivity(ActivityThread.java:4794) 
        at android.app.servertransaction.ResumeActivityItem.execute(ResumeActivityItem.java:54) 
        at android.app.servertransaction.ActivityTransactionItem.execute(ActivityTransactionItem.java:45) 
        at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:176) 
        at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97) 
        at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2214) 
        at android.os.Handler.dispatchMessage(Handler.java:106) 
        at android.os.Looper.loopOnce(Looper.java:201) 
        at android.os.Looper.loop(Looper.java:288) 
        at android.app.ActivityThread.main(ActivityThread.java:7842) 
        at java.lang.reflect.Method.invoke(Native Method) 
        at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548) 
        at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1003) 
```